### PR TITLE
Allow for parameters to be sent to Base class

### DIFF
--- a/BAC0/scripts/Base.py
+++ b/BAC0/scripts/Base.py
@@ -7,10 +7,10 @@
 """
 BasicScript - implement the BAC0.core.app.ScriptApplication
 Its basic function is to start and stop the bacpypes stack.
-Stopping the stack, frees the IP socket used for BACnet communications. 
+Stopping the stack, frees the IP socket used for BACnet communications.
 No communications will occur if the stack is stopped.
 
-Bacpypes stack enables Whois and Iam functions, since this minimum is needed to be 
+Bacpypes stack enables Whois and Iam functions, since this minimum is needed to be
 a BACnet device.  Other stack services can be enabled later (via class inheritance).
 [see: see BAC0.scripts.ReadWriteScript]
 
@@ -65,11 +65,15 @@ class Base:
         localIPAddr="127.0.0.1",
         localObjName="BAC0",
         DeviceId=None,
+        firmwareRevision="".join(sys.version.split("|")[:2]),
         maxAPDULengthAccepted="1024",
         maxSegmentsAccepted="1024",
         segmentationSupported="segmentedBoth",
         bbmdAddress=None,
         bbmdTTL=0,
+        modelName=CharacterString("BAC0 Scripting Tool"),
+        vendorId=842,
+        vendorName=CharacterString("SERVISYS inc."),
     ):
 
         self._log.debug("Configurating app")
@@ -100,15 +104,17 @@ class Base:
         self.localObjName = localObjName
 
         self.maxAPDULengthAccepted = maxAPDULengthAccepted
-        self.vendorId = 842
-        self.vendorName = CharacterString("SERVISYS inc.")
-        self.modelName = CharacterString("BAC0 Scripting Tool")
+        self.vendorId = vendorId
+        self.vendorName = vendorName
+        self.modelName = modelName
 
         self.discoveredDevices = None
         self.systemStatus = DeviceStatus(1)
 
         self.bbmdAddress = bbmdAddress
         self.bbmdTTL = bbmdTTL
+
+        self.firmwareRevision = firmwareRevision
 
         try:
             self.startApp()
@@ -133,7 +139,7 @@ class Base:
                 modelName=self.modelName,
                 systemStatus=self.systemStatus,
                 description="http://christiantremblay.github.io/BAC0/",
-                firmwareRevision="".join(sys.version.split("|")[:2]),
+                firmwareRevision=self.firmwareRevision,
                 applicationSoftwareVersion=infos.__version__,
                 protocolVersion=1,
                 protocolRevision=0,

--- a/BAC0/scripts/Complete.py
+++ b/BAC0/scripts/Complete.py
@@ -160,9 +160,16 @@ class Complete(Lite, Stats_Mixin):
         bbmdTTL=0,
         bokeh_server=True,
         flask_port=8111,
+        **params
     ):
         Lite.__init__(
-            self, ip=ip, mask=mask, port=port, bbmdAddress=bbmdAddress, bbmdTTL=bbmdTTL
+            self,
+            ip=ip,
+            mask=mask,
+            port=port,
+            bbmdAddress=bbmdAddress,
+            bbmdTTL=bbmdTTL,
+            **params
         )
         self.flask_port = flask_port
         if bokeh_server:

--- a/BAC0/scripts/Lite.py
+++ b/BAC0/scripts/Lite.py
@@ -64,7 +64,9 @@ class Lite(Base, WhoisIAm, ReadProperty, WriteProperty, Simulation):
         set to True.
     """
 
-    def __init__(self, ip=None, port=None, mask=None, bbmdAddress=None, bbmdTTL=0):
+    def __init__(
+        self, ip=None, port=None, mask=None, bbmdAddress=None, bbmdTTL=0, **params
+    ):
         self._log.info(
             "Starting BAC0 version {} ({})".format(
                 version, self.__module__.split(".")[-1]
@@ -93,7 +95,11 @@ class Lite(Base, WhoisIAm, ReadProperty, WriteProperty, Simulation):
             ip_addr = Address("{}/{}:{}".format(ip, mask, port))
         self._log.info("Using ip : {ip_addr}".format(ip_addr=ip_addr))
         Base.__init__(
-            self, localIPAddr=ip_addr, bbmdAddress=bbmdAddress, bbmdTTL=bbmdTTL
+            self,
+            localIPAddr=ip_addr,
+            bbmdAddress=bbmdAddress,
+            bbmdTTL=bbmdTTL,
+            **params
         )
 
         self.bokehserver = False

--- a/tests/test_BAC0_connect.py
+++ b/tests/test_BAC0_connect.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding utf-8 -*-
+
+"""
+Test BAC0.connect
+"""
+
+import pytest
+import time
+import BAC0
+
+
+def test_bac0_connect_ok():
+    fake_bac0_obj = "my_test_bac0"
+    fake_device_id = 666
+    fake_firmware_revision = "0.1.0"
+    fake_max_apdu_length = "2048"
+    fake_max_segments = "2048"
+    fake_bbmd_ttl = 10
+    fake_model_name = "Raspberry Pi"
+    fake_vendor_id = 999
+    fake_vendor_name = "Innotrode"
+
+    bacnet = BAC0.connect(
+        ip="127.0.2.1",
+        localObjName=fake_bac0_obj,
+        DeviceId=fake_device_id,
+        firmwareRevision=fake_firmware_revision,
+        maxAPDULengthAccepted=fake_max_apdu_length,
+        maxSegmentsAccepted=fake_max_segments,
+        bbmdTTL=fake_bbmd_ttl,
+        modelName=fake_model_name,
+        vendorId=fake_vendor_id,
+        vendorName=fake_vendor_name,
+    )
+
+    assert bacnet.localObjName == fake_bac0_obj
+    assert bacnet.Boid == fake_device_id
+    assert bacnet.firmwareRevision == fake_firmware_revision
+    assert bacnet.maxAPDULengthAccepted == fake_max_apdu_length
+    assert bacnet.maxSegmentsAccepted == fake_max_segments
+    assert bacnet.bbmdTTL == fake_bbmd_ttl
+    assert bacnet.modelName == fake_model_name
+    assert bacnet.vendorId == fake_vendor_id
+    assert bacnet.vendorName == fake_vendor_name
+
+    bacnet.disconnect()
+    time.sleep(2)

--- a/tests/test_BAC0_lite.py
+++ b/tests/test_BAC0_lite.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+# -*- coding utf-8 -*-
+
+"""
+Test BAC0.lite
+"""
+
+import pytest
+import time
+import BAC0
+
+
+def test_bac0_lite_ok():
+    fake_bac0_obj = "my_test_bac0"
+    fake_device_id = 666
+    fake_firmware_revision = "0.1.0"
+    fake_max_apdu_length = "2048"
+    fake_max_segments = "2048"
+    fake_bbmd_ttl = 10
+    fake_model_name = "Raspberry Pi"
+    fake_vendor_id = 999
+    fake_vendor_name = "Innotrode"
+
+    bacnet = BAC0.lite(
+        ip="127.0.1.1",
+        localObjName=fake_bac0_obj,
+        DeviceId=fake_device_id,
+        firmwareRevision=fake_firmware_revision,
+        maxAPDULengthAccepted=fake_max_apdu_length,
+        maxSegmentsAccepted=fake_max_segments,
+        bbmdTTL=fake_bbmd_ttl,
+        modelName=fake_model_name,
+        vendorId=fake_vendor_id,
+        vendorName=fake_vendor_name,
+    )
+
+    assert bacnet.localObjName == fake_bac0_obj
+    assert bacnet.Boid == fake_device_id
+    assert bacnet.firmwareRevision == fake_firmware_revision
+    assert bacnet.maxAPDULengthAccepted == fake_max_apdu_length
+    assert bacnet.maxSegmentsAccepted == fake_max_segments
+    assert bacnet.bbmdTTL == fake_bbmd_ttl
+    assert bacnet.modelName == fake_model_name
+    assert bacnet.vendorId == fake_vendor_id
+    assert bacnet.vendorName == fake_vendor_name
+
+    bacnet.disconnect()
+    time.sleep(2)


### PR DESCRIPTION
I would like to propose the following changes so the BAC0 instance can be configured.

- `firmwareRevision` - Rather than setting the Python version, I'd like to use this to indicate the version of the BAC0 software I'm writing
- `modelName` - This will be used to describe the particular hardware / firmware that is running my BAC0 code
- `vendorId` - I will be updating this after applying / registering for a specific vendorId with BAC0
- `vendorName` - This will be used to identify my organization

If you would like me to format the code in any way or apply the same changes to `Complete.py`, I would be happy to.

Merci!