### PR TITLE
Assign Exception to variable for reference

### DIFF
--- a/BAC0/scripts/Base.py
+++ b/BAC0/scripts/Base.py
@@ -181,7 +181,7 @@ class Base:
                 self._log.warning("Error opening socket: {}".format(error))
                 raise InitializationError("Error opening socket: {}".format(error))
             self._log.debug("Running")
-        except OSError:
+        except OSError as error:
             self._log.error("an error has occurred: {}".format(error))
             raise InitializationError("Error starting app: {}".format(error))
         finally:


### PR DESCRIPTION
I encountered the following error:
```
Traceback (most recent call last):
  File "/etc/beacon/venv/lib/python3.6/site-packages/BAC0/scripts/Base.py", line 171, in startApp
    self.this_device, self.localIPAddr
  File "/etc/beacon/venv/lib/python3.6/site-packages/BAC0/core/app/ScriptApplication.py", line 47, in __init__
    super().__init__(*args)
  File "/etc/beacon/venv/lib/python3.6/site-packages/bacpypes/app.py", line 514, in __init__
    self.mux = UDPMultiplexer(self.localAddress)
  File "/etc/beacon/venv/lib/python3.6/site-packages/bacpypes/bvllservice.py", line 96, in __init__
    self.directPort = UDPDirector(self.addrTuple)
  File "/etc/beacon/venv/lib/python3.6/site-packages/bacpypes/udp.py", line 154, in __init__
    self.bind(address)
  File "/usr/local/lib/python3.6/asyncore.py", line 329, in bind
    return self.socket.bind(addr)
OSError: [Errno 98] Address already in use

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/etc/beacon/beacon_web/batch/task.py", line 33, in wrapper
    _connection = bactalk.session()
  File "/etc/beacon/lib/bactalk.py", line 24, in session
    return BAC0.lite(**params)
  File "/etc/beacon/venv/lib/python3.6/site-packages/BAC0/scripts/Lite.py", line 102, in __init__
    **params
  File "/etc/beacon/venv/lib/python3.6/site-packages/BAC0/scripts/Base.py", line 120, in __init__
    self.startApp()
  File "/etc/beacon/venv/lib/python3.6/site-packages/BAC0/scripts/Base.py", line 185, in startApp
    self._log.error("an error has occurred: {}".format(error))
UnboundLocalError: local variable 'error' referenced before assignment
```