### PR TITLE
Fix infinite loop in logging

### DIFF
--- a/BAC0/core/utils/notes.py
+++ b/BAC0/core/utils/notes.py
@@ -113,8 +113,8 @@ def note_and_log(cls):
     cls.logname = "{} | {}".format(cls.__module__, cls.__name__)
     root_logger = logging.getLogger()
     cls._log = logging.getLogger("BAC0")
-    if not len(root_logger.handlers):
-        root_logger.addHandler(cls._log)
+    # if not len(root_logger.handlers):
+    #     root_logger.addHandler(cls._log)
 
     # Console Handler
     ch = logging.StreamHandler()


### PR DESCRIPTION
Whenever I try to start the Flask server it goes into an infinite loop unless I comment out these two lines. This line seems to add itself as one of its own handlers in its list of handlers, producing a stack trace like this:

```
  File "python3.7/logging/__init__.py", line 1586, in callHandlers
    hdlr.handle(record)
  File "python3.7/logging/__init__.py", line 1524, in handle
    self.callHandlers(record)
```

in a loop.

Could i be using the incorrect version of python or flask or something? 