### PR TITLE
ReadProperty::read_multiple should populate trends

### DIFF
--- a/BAC0/core/devices/Points.py
+++ b/BAC0/core/devices/Points.py
@@ -202,6 +202,8 @@ class Point:
                 prop_id_required=True,
             )
             for each in res:
+                if not each:
+                    continue
                 v, prop = each
                 self.properties.bacnet_properties[prop] = v
 

--- a/BAC0/core/devices/mixins/read_mixin.py
+++ b/BAC0/core/devices/mixins/read_mixin.py
@@ -529,11 +529,13 @@ class ReadProperty:
         device.read_multiple(['point1', 'point2', 'point3'], points_per_request = 10)
         """
         if isinstance(points_list, list):
-            (requests, _) = self._rpm_request_by_name(points_list)
-            for each in requests:
-                self.read_single(
-                    each, points_per_request=1, discover_request=discover_request
+            (requests, points) = self._rpm_request_by_name(points_list)
+            for (i, req) in enumerate(requests):
+                val = self.read_single(
+                    req, points_per_request=1, discover_request=discover_request
                 )
+                if val is not None and val != "":
+                    points[i]._trend(val)
         else:
             self.read_single(
                 points_list, points_per_request=1, discover_request=discover_request


### PR DESCRIPTION
Ok, another small follow-on to #229 - looks like the `point._trend` function gets called in the `ReadPropertyMultiple` version and that's how polling actually populates `point.history`. So I've copied that logic over to the single read version. 