### PR TITLE
Don't raise in `_discoverPoints` when TrendLog init fails

### DIFF
--- a/BAC0/core/devices/Device.py
+++ b/BAC0/core/devices/Device.py
@@ -855,6 +855,7 @@ class DeviceDisconnected(Device):
                 self.new_state(RPDeviceConnected)
 
             except (NoResponseFromController, AttributeError) as error:
+                self._log.warning("Error connecting: %s", error)
                 if self.properties.db_name:
                     self.new_state(DeviceFromDB)
                 else:

--- a/BAC0/core/devices/mixins/read_mixin.py
+++ b/BAC0/core/devices/mixins/read_mixin.py
@@ -385,6 +385,8 @@ class ReadPropertyMultiple:
         for each in retrieve_type(objList, "trendLog"):
             point_address = str(each[1])
             tl = TrendLog(point_address, self, read_log_on_creation=False)
+            if tl.properties.log_device_object_property is None:
+                continue
             ldop_type, ldop_addr = (
                 tl.properties.log_device_object_property.objectIdentifier
             )


### PR DESCRIPTION
This can happen if the read for `logDeviceObjectProperty` fails while building the `TrendLog` object. Currently there's a debug message generated, for example:

`DEBUG   | Property Access Error for <bacpypes.basetypes.ErrorType object at 0x7f0394564940>`

but no other information and the exception stops the controller's points list from getting populated