### PR TITLE
fix nonetype error when connecting and presentValue == None

### DIFF
--- a/BAC0/core/devices/mixins/read_mixin.py
+++ b/BAC0/core/devices/mixins/read_mixin.py
@@ -5,7 +5,7 @@
 # Licensed under LGPLv3, see file LICENSE in this source tree.
 #
 """
-read_mixin.py - Add ReadProperty and ReadPropertyMultiple to a device 
+read_mixin.py - Add ReadProperty and ReadPropertyMultiple to a device
 """
 # --- standard Python modules ---
 
@@ -262,7 +262,7 @@ class RPMObjectsProcessing:
                     presentValue = float(presentValue)
                 elif obj_type == "multi":
                     presentValue = int(presentValue)
-            except TypeError:
+            except (TypeError, ValueError):
                 presentValue = None
             try:
                 point_description = point_infos[_find_propid_index("description")]

--- a/BAC0/core/devices/mixins/read_mixin.py
+++ b/BAC0/core/devices/mixins/read_mixin.py
@@ -257,10 +257,13 @@ class RPMObjectsProcessing:
 
             pointName = point_infos[_find_propid_index("objectName")]
             presentValue = point_infos[_find_propid_index("presentValue")]
-            if obj_type == "analog":
-                presentValue = float(presentValue)
-            elif obj_type == "multi":
-                presentValue = int(presentValue)
+            try:
+                if obj_type == "analog":
+                    presentValue = float(presentValue)
+                elif obj_type == "multi":
+                    presentValue = int(presentValue)
+            except TypeError:
+                presentValue = None
             try:
                 point_description = point_infos[_find_propid_index("description")]
             except KeyError:


### PR DESCRIPTION
This fixes the following stack trace we intermittently see while connecting to a particular device

```
self.controller = BAC0.device(
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 196, in __init__
    self.new_state(DeviceDisconnected)
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 212, in new_state
    self._init_state()
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 833, in _init_state
    self.connect()
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 868, in connect
    self.new_state(RPMDeviceConnected)
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 212, in new_state
    self._init_state()
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 455, in _init_state
    self._buildPointList()
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/Device.py", line 534, in _buildPointList
    self.properties.objects_list, self.points, self._list_of_trendlogs = self._discoverPoints(
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/mixins/read_mixin.py", line 159, in _discoverPoints
    self._process_new_objects(
  File "/usr/local/lib/python3.8/dist-packages/BAC0/core/devices/mixins/read_mixin.py", line 260, in _process_new_objects
    presentValue = float(presentValue)
TypeError: float() argument must be a string or a number, not 'NoneType'
```