### PR TITLE
fix iterator error when discovering slow networks

### DIFF
--- a/BAC0/scripts/Lite.py
+++ b/BAC0/scripts/Lite.py
@@ -262,7 +262,7 @@ class Lite(
                     if network < 65535:
                         _networks.append(network)
             elif networks == "known":
-                _networks = self.known_network_numbers
+                _networks = self.known_network_numbers.copy()
             else:
                 if networks < 65535:
                     _networks.append(networks)


### PR DESCRIPTION
This fixes the following crash for me, seemingly happens when dealing with particularly slow devices

```
Traceback (most recent call last):
  File "scrape-debugger.py", line 8, in <module>
    devices = bacnet.discover()
  File "/usr/local/lib/python3.8/dist-packages/BAC0/scripts/Lite.py", line 242, in discover
    for network in _networks:
RuntimeError: Set changed size during iteration
```