### PR TITLE
Update Device.py

### DIFF
--- a/BAC0/core/devices/Device.py
+++ b/BAC0/core/devices/Device.py
@@ -1061,6 +1061,10 @@ class DeviceFromDB(DeviceConnected):
         self.properties.serving_chart = {}
         self.properties.charts = []
         self.properties.multistates = self._props["multistates"]
+        self.properties.auto_save = self._props["auto_save"]
+        self.properties.save_resampling = self._props["save_resampling"]
+        self.properties.clear_history_on_save = self._props["clear_history_on_save"]
+        self.properties.default_history_size = self._props["history_size"]
         self._log.info("Device restored from db")
         self._log.info(
             'You can reconnect to network using : "device.connect(network=bacnet)"'


### PR DESCRIPTION
This solves the reconnecting issue after a device is being disconnected. The issue occurs where DeviceProperties does not save "default_history_size" when connecting from the database.
The issue can be replicated for the original file by executing the following command after the device is being connected: 
Device.properties (the array has the attribute "default_history_size")
Device.disconnect()
Device.properties (the array does NOT have the attribute "default_history_size")
Device.connect(network=bacnet) - fails because not attribute call default_history_size. Also missing other important properties.