### PR TITLE
Continue device connection with empty/null objectName prop

### DIFF
--- a/BAC0/core/devices/Device.py
+++ b/BAC0/core/devices/Device.py
@@ -883,11 +883,10 @@ class DeviceDisconnected(Device):
                 else:
                     segmentation_supported = True
 
-                if name:
-                    if segmentation_supported:
-                        self.new_state(RPMDeviceConnected)
-                    else:
-                        self.new_state(RPDeviceConnected)
+                if segmentation_supported:
+                    self.new_state(RPMDeviceConnected)
+                else:
+                    self.new_state(RPDeviceConnected)
 
             except SegmentationNotSupported:
                 self.segmentation_supported = False

--- a/BAC0/core/devices/mixins/read_mixin.py
+++ b/BAC0/core/devices/mixins/read_mixin.py
@@ -5,7 +5,7 @@
 # Licensed under LGPLv3, see file LICENSE in this source tree.
 #
 """
-read_mixin.py - Add ReadProperty and ReadPropertyMultiple to a device 
+read_mixin.py - Add ReadProperty and ReadPropertyMultiple to a device
 """
 # --- standard Python modules ---
 
@@ -381,7 +381,7 @@ class RPObjectsProcessing:
             presentValue = self.read_single(
                 "{} {} presentValue ".format(point_type, point_address)
             )
-            if obj_type == "analog":
+            if obj_type == "analog" and presentValue:
                 presentValue = float(presentValue)
 
             _newpoints.append(


### PR DESCRIPTION
We were missing a whole bunch of devices at a site, turns out a number of the controllers there don't reliably report `objectName`. This fixes the connect logic to continue regardless, which allows us to pull the point list for devices with no name. 