### PR TITLE
Empty point array fix

### DIFF
--- a/BAC0/core/devices/Points.py
+++ b/BAC0/core/devices/Points.py
@@ -306,9 +306,11 @@ class Point:
         returns: last value read
         """
         if _PANDAS:
-            return self.history.dropna().index[-1]
+            last_val = self.history.dropna()
+            last_val_clean = None if len(last_val) == 0 else last_val.iloc[-1]
+            return last_val_clean
         else:
-            return self._history.timestamp[-1]
+            return self._history.value[-1]
 
     @property
     def history(self) -> t.Dict[datetime, t.Union[int, float, str]]:


### PR DESCRIPTION
The "lastTimestamp" function will break if a point has no last value. The following logic was added to avoid such scenarios.