### PR TITLE
Pandas Deprecated Class and Functions

### DIFF
--- a/BAC0/db/sql.py
+++ b/BAC0/db/sql.py
@@ -19,7 +19,7 @@ import sqlite3
 
 try:
     import pandas as pd
-    from pandas.core.base import DataError
+    from pandas.errors import DataError
     from pandas.io import sql
 
     try:
@@ -178,8 +178,8 @@ class SQLMixin(object):
             return (
                 df.resample(resampling_freq)
                 .last()
-                .fillna(method="ffill")
-                .fillna(method="bfill")
+                .ffill()
+                .bfill()
             )
         else:
             return df

--- a/BAC0/web/BokehRenderer.py
+++ b/BAC0/web/BokehRenderer.py
@@ -160,12 +160,12 @@ class DynamicPlotHandler(Handler):
         df["time_s"] = df["index"].apply(str)
         try:
             df = (
-                df.fillna(method="ffill")
-                .fillna(method="bfill")
+                df.ffill()
+                .bfill()
                 .replace(["inactive", "active"], [0, 1])
             )
         except TypeError:
-            df = df.fillna(method="ffill").fillna(method="bfill")
+            df = df.ffill().bfill()
         return df
 
     def make_glyph_invisible(self):


### PR DESCRIPTION
BAC0 save function is broken due to deprecations in the new pandas version. The following updates fix the issues.

BAC0/db/sql.py:
DataError function is deprecated, and the new location is pandas.errors script.
fillna() function is replaced with ffill() and bfill() functions to avoid future deprecations. 

BAC0/web/BokehRender.py:
fillna() function is replaced with ffill() and bfill() functions to avoid future deprecations. 