### PR TITLE
Add a sleep arg to `whois()` and `discover()` to support variance in response latency

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,7 @@
 name: Upload Python Package
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch
 
 permissions:
   contents: read

--- a/BAC0/core/functions/Discover.py
+++ b/BAC0/core/functions/Discover.py
@@ -163,7 +163,7 @@ class Discover:
     Define BACnet WhoIs and IAm functions.
     """
 
-    def whois(self, *args, global_broadcast=False, destination=None):
+    def whois(self, *args, global_broadcast=False, destination=None, sleep_ms=100):
         """
         Build a WhoIs request
 
@@ -175,6 +175,7 @@ class Discover:
             whois(global_broadcast=True) # WhoIs broadcast globally.  Every device will respond with an IAm
             whois('2:5')                 # WhoIs looking for the device at (Network 2, Address 5)
             whois('10 1000')             # WhoIs looking for devices in the ID range (10 - 1000)
+            whois(sleep_ms=3000)         # WhoIs waiting for 3 seconds for responses
 
         """
         if not self._started:
@@ -221,8 +222,7 @@ class Discover:
         if iocb.ioError:  # unsuccessful: error/reject/abort
             pass
 
-        for each in range(100):
-            time.sleep(1 / 1000)
+        time.sleep(sleep_ms / 1000)
         self.discoveredDevices = self.this_application.i_am_counter
         return self.this_application._last_i_am_received
 

--- a/BAC0/scripts/Lite.py
+++ b/BAC0/scripts/Lite.py
@@ -220,6 +220,7 @@ class Lite(
         limits: t.Tuple[int, int] = (0, 4194303),
         global_broadcast: bool = False,
         reset: bool = False,
+        whois_sleep_ms: int = 100,
     ):
         """
         Discover is meant to be the function used to explore the network when we
@@ -286,6 +287,7 @@ class Lite(
                         deviceInstanceRangeHighLimit,
                     ),
                     global_broadcast=global_broadcast,
+                    sleep_ms=whois_sleep_ms,
                 )
                 for each in _res:
                     found.append(each)
@@ -301,6 +303,7 @@ class Lite(
                     deviceInstanceRangeLowLimit, deviceInstanceRangeHighLimit
                 ),
                 global_broadcast=global_broadcast,
+                sleep_ms=whois_sleep_ms,
             )
             for each in _res:
                 found.append(each)


### PR DESCRIPTION
The current hardcoded 100ms sleep seems like it frequently isn't enough and leads to inconsistent results (https://github.com/ChristianTremblay/BAC0/issues/431). This arg allows us to easily modify that sleep from the call site so we can mitigate that inconsistency.