### PR TITLE
Remove debug logging in core.devices.local.object

### DIFF
--- a/BAC0/core/devices/local/object.py
+++ b/BAC0/core/devices/local/object.py
@@ -65,7 +65,6 @@ class ObjectFactory(object):
         self._properties = ObjectFactory.default_properties(
             objectType, properties, is_commandable, relinquish_default
         )
-        print(f"Obj {objectType} of type {type(objectType)}")
         if objectType is not TrendLogObject:
             pv_datatype = ObjectFactory.get_pv_datatype(objectType)
 


### PR DESCRIPTION
this looks like forgotten debug logging.

prints stuff like this to stdout ignoring logging settings

```
Obj <class 'bacpypes.object.MultiStateValueObject'> of type <class 'type'>
Obj <class 'bacpypes.object.MultiStateInputObject'> of type <class 'type'>
Obj <class 'bacpypes.object.AnalogInputObject'> of type <class 'type'>
Obj <class 'bacpypes.object.AnalogValueObject'> of type <class 'type'>
```