### PR TITLE
allow setting relinquish_default in multistate_input/output/value

### DIFF
--- a/BAC0/core/devices/local/models.py
+++ b/BAC0/core/devices/local/models.py
@@ -178,7 +178,6 @@ def multistate_input(**kwargs):
     kwargs["name"] = set_default_if_not_provided("name", "MSI", **kwargs)
     kwargs["objectType"] = MultiStateInputObject
     kwargs["is_commandable"] = True
-    kwargs["relinquish_default"] = Unsigned(1)
 
     return multistate(**kwargs)
 
@@ -187,7 +186,6 @@ def multistate_output(**kwargs):
     kwargs["name"] = set_default_if_not_provided("name", "MSO", **kwargs)
     kwargs["objectType"] = MultiStateOutputObject
     kwargs["is_commandable"] = True
-    kwargs["relinquish_default"] = Unsigned(1)
 
     return multistate(**kwargs)
 
@@ -196,7 +194,6 @@ def multistate_value(**kwargs):
     kwargs["name"] = set_default_if_not_provided("name", "MSV", **kwargs)
     kwargs["objectType"] = MultiStateValueObject
     kwargs["is_commandable"] = True
-    kwargs["relinquish_default"] = Unsigned(1)
 
     return multistate(**kwargs)
 


### PR DESCRIPTION
`multistate` already sets the `relinquish_default` to `Unsigned(1)`.

overwriting `kwargs["relinquish_default"]` in `multistate_input`, `multistate_output` and `multistate_value` prevents callers from changing it.