### PR TITLE
462- Do not coerce binary/enum Points to values if None when trending

### DIFF
--- a/BAC0/core/devices/Points.py
+++ b/BAC0/core/devices/Points.py
@@ -258,7 +258,7 @@ class Point:
                 return None
             return val
 
-    def _trend(self, res: t.Union[float, int, str]) -> None:
+    def _trend(self, res: t.Optional[t.Union[float, int, str]]) -> None:
         now = datetime.now().astimezone()
         self._history.timestamp.append(now)
         self._history.value.append(res)
@@ -875,7 +875,8 @@ class BooleanPoint(Point):
         self.properties.units_state = tuple(str(x) for x in units_state)
 
     def _trend(self, res):
-        res = "1: active" if res == BinaryPV.active else "0: inactive"
+        if res is not None:
+            res = "1: active" if res == BinaryPV.active else "0: inactive"
         super()._trend(res)
 
     @property
@@ -1009,7 +1010,8 @@ class EnumPoint(Point):
         )
 
     def _trend(self, res):
-        res = f"{res}: {self.get_state(res)}"
+        if res is not None:
+            res = f"{res}: {self.get_state(res)}"
         super()._trend(res)
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "BAC0"
-version = "2024.09.20dev"
+version = "2024.09.20"
 description = "BACnet Scripting Framework for testing DDC Controls"
 authors = [{name = "Christian Tremblay", email = "christian.tremblay@servisys.com"}]
 readme = "README.md"


### PR DESCRIPTION
In the event these are None, we should propogate the None value into super()._trend

Also updating the _trend signature to include this possibility

Addresses https://github.com/ChristianTremblay/BAC0/issues/462