### PR TITLE
COV callback #551

### DIFF
--- a/BAC0/scripts/Base.py
+++ b/BAC0/scripts/Base.py
@@ -331,7 +331,7 @@ class Base:
         return self._routers
 
     @classmethod
-    def extract_value_from_primitive_data(value):
+    def extract_value_from_primitive_data(self, value):
         if isinstance(value, float):
             return float(value)
         # elif isinstance(value, Boolean):


### PR DESCRIPTION
Update Base.py add missing self argument 
Fixed #551 for me

Then I am able to subscribe to a value with this code:
```python
def my_point_callback(property_identifier, property_value):
    print(f"{property_identifier}: {property_value}")

await mycontrollers['AnalogValue-1'].subscribe_cov(callback=my_point_callback)
```