### PR TITLE
Fix lastValue if pandas is not available.

### DIFF
--- a/BAC0/core/devices/Points.py
+++ b/BAC0/core/devices/Points.py
@@ -302,7 +302,7 @@ class Point:
             last_val_clean = None if len(last_val) == 0 else last_val.iloc[-1]
             return last_val_clean
         else:
-            return None if len(self._history.value) == 0 else self._history.value.iloc[-1]
+            return None if len(self._history.value) == 0 else self._history.value[-1]
 
     @property
     def lastTimestamp(self):


### PR DESCRIPTION
Currently, accessing `lastValue` on a point with history available fails if pandas is not installed, because the code tries to access `self._history.value.iloc[-1]`. But without pandas, `self._history.value` is just a list, which doesn't have an `.iloc` attribute.

The proposed fix just returns the last element of the list.