### PR TITLE
Fix subscriptions to binary objects

### DIFF
--- a/BAC0/core/devices/local/factory.py
+++ b/BAC0/core/devices/local/factory.py
@@ -14,7 +14,7 @@ from bacpypes3.local.binary import (
     BinaryOutputObject,
     BinaryValueObject,
 )
-from bacpypes3.local.cov import COVIncrementCriteria
+from bacpypes3.local.cov import criteria_type_map
 from bacpypes3.local.multistate import (
     MultiStateInputObject,
     MultiStateOutputObject,
@@ -146,7 +146,7 @@ class ObjectFactory(object):
                 self.objects[objectName], datatype=_localTrendLogDataType
             )  # this will need to be fed by another process.
         else:
-            self.objects[objectName]._cov_criteria = COVIncrementCriteria
+            self.objects[objectName]._cov_criteria = criteria_type_map[objectType.objectType]
 
     def validate_instance(self, objectType, instance):
         _warning = True


### PR DESCRIPTION
In current BAC0 code there are attempts to retrieve properties via Change-of-Value subscriptions that do not exist for certain object types. This is because the code assigns "COVIncrementCriteria" to define the properties it wishes to retrieve from the Bacnet server to all object types. This list of properties is incorrect for some types, for example Binary-* objects do not define "covIncrement".

This error is strangely suppressed during regular code execution, but can be seen occurring using a debugger (or adding print lines) to "bacpypes3.local.cov.py:157:
```
property_value = getattr(obj, prop)
```
This line is executed on the server side to respond to a list of properties requested from it. When it tries to retrieve "covIncrement" for a binary-output object we see the following exception:
```
AttributeError: 'BinaryOutputObject' object has no attribute 'covIncrement'
```

This PR fixes this issue by using the `criteria_type_map` that already exists inside bacpypes3, and correctly aligns different object types with the expected properties that should be retrieved by default on a CoV.

This can be tested using this program: 
```
ADDRESS = '192.168.122.1'
import asyncio

import BAC0
from BAC0.core.devices.local.factory import (
    analog_input, binary_output
)

BAC0.log_level(level="ERROR", logger="ERROR", log_this=False)

async def main():
    async with BAC0.start(ip=ADDRESS, deviceId=123) as bacnet:
        async with BAC0.start(ip=ADDRESS, port=47809, deviceId=456) as fake_device:
            ref = analog_input(name="TW1", description="Water temperature 1", properties={"units": "degreesCelsius"})

            ref = binary_output(name="Night", description="Day/Night flag", properties={"inactiveText": "day", "activeText": "night"})

            ref.add_objects_to_application(fake_device)

            fake_device["TW1"].presentValue = 123
            fake_device["Night"].presentValue = True

            # # Explicitly point to ip:port to communicate
            dev = await BAC0.device(f"{ADDRESS}:47809", 456, bacnet)

            def ai_print(*args, **kwargs):
                print(f"ai_print {args} {kwargs}")

            ai = dev["TW1"]
            await ai.subscribe_cov(callback=ai_print)

            def bo_print(*args, **kwargs):
                print(f"bo_print  {args} {kwargs}")

            bo = dev["Night"]
            await bo.subscribe_cov(callback=bo_print)

            # Give time for subscriptions to run
            await asyncio.sleep(5)

if __name__ == "__main__":
    asyncio.run(main())
```


Executing this against the current `main` branch prints only the analog input lines (as well as some UserWarnings that I've removed for brevity):
```
ai_print () {'property_identifier': <PropertyIdentifier: present-value>, 'property_value': 123.0}
ai_print () {'property_identifier': <PropertyIdentifier: status-flags>, 'property_value': <StatusFlags: >}
```
Executing the code against this PR yields the extra print statements from the binary output as well:

```
ai_print () {'property_identifier': <PropertyIdentifier: present-value>, 'property_value': 123.0}
bo_print  () {'property_identifier': <PropertyIdentifier: present-value>, 'property_value': <BinaryPV: active>}
ai_print () {'property_identifier': <PropertyIdentifier: status-flags>, 'property_value': <StatusFlags: >}
bo_print  () {'property_identifier': <PropertyIdentifier: status-flags>, 'property_value': <StatusFlags: >}
```