### PR TITLE
Move object registration so it only happens once

### DIFF
--- a/BAC0/scripts/Base.py
+++ b/BAC0/scripts/Base.py
@@ -110,13 +110,14 @@ class Base:
         # Register Servisys
         try:
             _BAC0_vendor = VendorInfo(vendorId)
+            _BAC0_vendor.register_object_class(
+                ObjectTypesSupported.networkPort, NetworkPortObject
+            )
+            _BAC0_vendor.register_object_class(ObjectTypesSupported.device, DeviceObject)
         except RuntimeError:
             pass  # we are re-running the script... forgive us
             _BAC0_vendor = get_vendor_info(vendorId)
-        _BAC0_vendor.register_object_class(
-            ObjectTypesSupported.networkPort, NetworkPortObject
-        )
-        _BAC0_vendor.register_object_class(ObjectTypesSupported.device, DeviceObject)
+
 
         self.timehandler = TimeHandler(tz=timezone)
 


### PR DESCRIPTION
These objects only need to be registered once, and bacpypes3 will emit a UserWarning if they are registered multiple times. This can occur if you are running nested Bacnet servers in one script (see ["Multiple BAC0 instances on one machine"](https://bac0.readthedocs.io/en/latest/connect.html#multiple-bac0-instances-on-one-machine) documentation)

This change can be tested with this code:
```
ADDRESS = '192.168.122.1'
import asyncio

import BAC0

BAC0.log_level(level="ERROR", logger="ERROR", log_this=False)

async def main():
    async with BAC0.start(ip=ADDRESS, deviceId=123) as bacnet:
        async with BAC0.start(ip=ADDRESS, port=47809, deviceId=456) as fake_device:
            # Give time for subscriptions to run
            await asyncio.sleep(5)

if __name__ == "__main__":
    asyncio.run(main())

```

On the current `main` this causes two `UserWarning` errors to be printed:
```
/scratch/eyh46967/dev/bacnet/BAC0/.venv/lib/python3.13/site-packages/bacpypes3/vendor.py:109: UserWarning: object type 56 for vendor identifier 842 already registered: <class 'bacpypes3.local.networkport.NetworkPortObject'>
  warnings.warn(
/scratch/eyh46967/dev/bacnet/BAC0/.venv/lib/python3.13/site-packages/bacpypes3/vendor.py:109: UserWarning: object type 8 for vendor identifier 842 already registered: <class 'bacpypes3.local.device.DeviceObject'>
  warnings.warn(
```


With this PR the output is silent.