### PR TITLE
fix invalid fdBBMDAddress in normal mode

### DIFF
--- a/BAC0/scripts/Base.py
+++ b/BAC0/scripts/Base.py
@@ -205,6 +205,24 @@ class Base:
                 mode = "bbmd"
             else:
                 mode = "normal"
+
+            network_port_cfg = {
+                "ip-address": str(self.localIPAddr),
+                "ip-subnet-mask": str(self.localIPAddr.netmask),
+                "bacnet-ip-udp-port": self.localIPAddr.addrPort,
+                "network-number": None,
+                "bacnet-ip-mode": mode,
+            }
+            if mode == "foreign":
+                network_port_cfg.update(
+                    {
+                        "fd-bbmd-address": sequence_to_json(
+                            HostNPort(self.bbmdAddress)
+                        ),
+                        "fd-subscription-lifetime": self.bbmdTTL,
+                    }
+                )
+
             cfg = {
                 "BAC0": {
                     "bbmdAddress": self.bbmdAddress,
@@ -224,15 +242,7 @@ class Base:
                     # "location": self.location,
                     # "description": self.description
                 },
-                "network-port": {
-                    "ip-address": str(self.localIPAddr),
-                    "ip-subnet-mask": str(self.localIPAddr.netmask),
-                    "bacnet-ip-udp-port": self.localIPAddr.addrPort,
-                    "network-number": None,
-                    "fd-bbmd-address": sequence_to_json(HostNPort(self.bbmdAddress)),
-                    "fd-subscription-lifetime": self.bbmdTTL,
-                    "bacnet-ip-mode": mode,
-                },
+                "network-port": network_port_cfg,
             }
             if mode == "bbmd":
                 # bdt_json_seq = [f"BDTEntry({addr})" for addr in self.bdtable]

--- a/tests/test_NetworkPort.py
+++ b/tests/test_NetworkPort.py
@@ -1,0 +1,41 @@
+import pytest
+
+import BAC0
+from bacpypes3.primitivedata import ObjectIdentifier
+from bacpypes3.service.object import read_property_to_result_element
+
+
+@pytest.mark.asyncio
+async def test_missing_fd_bbmd_address_is_encoded_as_property_error():
+    async with BAC0.start(ip="127.0.0.1/24", port=47820) as bacnet:
+        network_port = bacnet.this_application.app.get_object_id(
+            ObjectIdentifier("network-port,1")
+        )
+
+        result = await read_property_to_result_element(
+            network_port, "fdBBMDAddress"
+        )
+
+        error = result.readResult.propertyAccessError
+        assert str(error.errorClass) == "property"
+        assert str(error.errorCode) == "unknown-property"
+
+
+@pytest.mark.asyncio
+async def test_fd_bbmd_address_is_available_in_foreign_mode():
+    async with BAC0.start(
+        ip="127.0.0.1/24",
+        port=47821,
+        bbmdAddress="127.0.0.1:47808",
+        bbmdTTL=60,
+    ) as bacnet:
+        network_port = bacnet.this_application.app.get_object_id(
+            ObjectIdentifier("network-port,1")
+        )
+
+        result = await read_property_to_result_element(
+            network_port, "fdBBMDAddress"
+        )
+
+        assert result.readResult.propertyAccessError is None
+        assert result.readResult.propertyValue is not None


### PR DESCRIPTION
This fixes an invalid `fdBBMDAddress` created in normal mode.

FD properties are now only added in foreign mode.

Added tests for normal and foreign modes.